### PR TITLE
Add --insecure-skip-tls-verify flag to disable SSL certificate verification

### DIFF
--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -56,6 +56,7 @@ type GlobalOptions struct {
 	CacheDir        string
 	NoCache         bool
 	CACerts         []string
+	SkipSSLVerify   bool
 	TLSClientCert   string
 	CleanupCache    bool
 
@@ -105,6 +106,7 @@ func init() {
 	f.BoolVar(&globalOptions.NoCache, "no-cache", false, "do not use a local cache")
 	f.StringSliceVar(&globalOptions.CACerts, "cacert", nil, "`file` to load root certificates from (default: use system certificates)")
 	f.StringVar(&globalOptions.TLSClientCert, "tls-client-cert", "", "path to a file containing PEM encoded TLS client certificate and private key")
+	f.BoolVar(&globalOptions.SkipSSLVerify, "skip-ssl-verify", false, "skip SSL certificate verification (insecure)")
 	f.BoolVar(&globalOptions.CleanupCache, "cleanup-cache", false, "auto remove old cache directories")
 	f.IntVar(&globalOptions.LimitUploadKb, "limit-upload", 0, "limits uploads to a maximum rate in KiB/s. (default: unlimited)")
 	f.IntVar(&globalOptions.LimitDownloadKb, "limit-download", 0, "limits downloads to a maximum rate in KiB/s. (default: unlimited)")
@@ -581,6 +583,7 @@ func open(s string, gopts GlobalOptions, opts options.Options) (restic.Backend, 
 	tropts := backend.TransportOptions{
 		RootCertFilenames:        globalOptions.CACerts,
 		TLSClientCertKeyFilename: globalOptions.TLSClientCert,
+		SkipSSLVerify:            globalOptions.SkipSSLVerify,
 	}
 	rt, err := backend.Transport(tropts)
 	if err != nil {
@@ -652,6 +655,7 @@ func create(s string, opts options.Options) (restic.Backend, error) {
 	tropts := backend.TransportOptions{
 		RootCertFilenames:        globalOptions.CACerts,
 		TLSClientCertKeyFilename: globalOptions.TLSClientCert,
+		SkipSSLVerify:            globalOptions.SkipSSLVerify,
 	}
 	rt, err := backend.Transport(tropts)
 	if err != nil {

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -45,23 +45,23 @@ const TimeFormat = "2006-01-02 15:04:05"
 
 // GlobalOptions hold all global options for restic.
 type GlobalOptions struct {
-	Repo            string
-	PasswordFile    string
-	PasswordCommand string
-	KeyHint         string
-	Quiet           bool
-	Verbose         int
-	NoLock          bool
-	JSON            bool
-	CacheDir        string
-	NoCache         bool
-	CACerts         []string
-	SkipSSLVerify   bool
-	TLSClientCert   string
-	CleanupCache    bool
+	Repo                  string
+	PasswordFile          string
+	PasswordCommand       string
+	KeyHint               string
+	Quiet                 bool
+	Verbose               int
+	NoLock                bool
+	JSON                  bool
+	CacheDir              string
+	NoCache               bool
+	CACerts               []string
+	InsecureSkipTLSVerify bool
+	TLSClientCert         string
+	CleanupCache          bool
 
-	LimitUploadKb   int
-	LimitDownloadKb int
+	LimitUploadKb         int
+	LimitDownloadKb       int
 
 	ctx      context.Context
 	password string
@@ -106,7 +106,7 @@ func init() {
 	f.BoolVar(&globalOptions.NoCache, "no-cache", false, "do not use a local cache")
 	f.StringSliceVar(&globalOptions.CACerts, "cacert", nil, "`file` to load root certificates from (default: use system certificates)")
 	f.StringVar(&globalOptions.TLSClientCert, "tls-client-cert", "", "path to a file containing PEM encoded TLS client certificate and private key")
-	f.BoolVar(&globalOptions.SkipSSLVerify, "skip-ssl-verify", false, "skip SSL certificate verification (insecure)")
+	f.BoolVar(&globalOptions.InsecureSkipTLSVerify, "insecure-skip-tls-verify", false, "skip TLS certificate verification when connecting to the repo (insecure)")
 	f.BoolVar(&globalOptions.CleanupCache, "cleanup-cache", false, "auto remove old cache directories")
 	f.IntVar(&globalOptions.LimitUploadKb, "limit-upload", 0, "limits uploads to a maximum rate in KiB/s. (default: unlimited)")
 	f.IntVar(&globalOptions.LimitDownloadKb, "limit-download", 0, "limits downloads to a maximum rate in KiB/s. (default: unlimited)")
@@ -583,7 +583,7 @@ func open(s string, gopts GlobalOptions, opts options.Options) (restic.Backend, 
 	tropts := backend.TransportOptions{
 		RootCertFilenames:        globalOptions.CACerts,
 		TLSClientCertKeyFilename: globalOptions.TLSClientCert,
-		SkipSSLVerify:            globalOptions.SkipSSLVerify,
+		InsecureSkipTLSVerify:    globalOptions.InsecureSkipTLSVerify,
 	}
 	rt, err := backend.Transport(tropts)
 	if err != nil {
@@ -655,7 +655,7 @@ func create(s string, opts options.Options) (restic.Backend, error) {
 	tropts := backend.TransportOptions{
 		RootCertFilenames:        globalOptions.CACerts,
 		TLSClientCertKeyFilename: globalOptions.TLSClientCert,
-		SkipSSLVerify:            globalOptions.SkipSSLVerify,
+		InsecureSkipTLSVerify:    globalOptions.InsecureSkipTLSVerify,
 	}
 	rt, err := backend.Transport(tropts)
 	if err != nil {

--- a/internal/backend/http_transport.go
+++ b/internal/backend/http_transport.go
@@ -22,6 +22,9 @@ type TransportOptions struct {
 
 	// contains the name of a file containing the TLS client certificate and private key in PEM format
 	TLSClientCertKeyFilename string
+
+	// Skip SSL certificate verification
+	SkipSSLVerify bool
 }
 
 // readPEMCertKey reads a file and returns the PEM encoded certificate and key
@@ -76,6 +79,10 @@ func Transport(opts TransportOptions) (http.RoundTripper, error) {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		TLSClientConfig:       &tls.Config{},
+	}
+
+	if opts.SkipSSLVerify {
+		tr.TLSClientConfig.InsecureSkipVerify = true
 	}
 
 	if opts.TLSClientCertKeyFilename != "" {

--- a/internal/backend/http_transport.go
+++ b/internal/backend/http_transport.go
@@ -23,8 +23,8 @@ type TransportOptions struct {
 	// contains the name of a file containing the TLS client certificate and private key in PEM format
 	TLSClientCertKeyFilename string
 
-	// Skip SSL certificate verification
-	SkipSSLVerify bool
+	// Skip TLS certificate verification
+	InsecureSkipTLSVerify bool
 }
 
 // readPEMCertKey reads a file and returns the PEM encoded certificate and key
@@ -81,7 +81,7 @@ func Transport(opts TransportOptions) (http.RoundTripper, error) {
 		TLSClientConfig:       &tls.Config{},
 	}
 
-	if opts.SkipSSLVerify {
+	if opts.InsecureSkipTLSVerify {
 		tr.TLSClientConfig.InsecureSkipVerify = true
 	}
 


### PR DESCRIPTION
This PR adds a command line flag to Restic to skip SSL certificate verification. We need something like this in both Velero and Restic as the first step toward supporting self-signed certificates for MigStorage. 

See https://github.com/fusor/mig-controller/issues/270 for more information.

Before:
```
./restic init -r s3:https://s3-default.apps.cluster-sml4xaliosduf.sml4xaliosduf.mg.dog8code.com:/restic-bucket                  
Fatal: create repository at s3:https://s3-default.apps.cluster-sml4xaliosduf.sml4xaliosduf.mg.dog8code.com:/restic-bucket failed: client.BucketExists: Get https://s3-default.apps.cluster-sml4xaliosduf.sml4xaliosduf.mg.dog8code.com/restic-bucket/?location=: x509: certificate signed by unknown authority
```
After:
```
./restic init -r s3:https://s3-default.apps.cluster-sml4xaliosduf.sml4xaliosduf.mg.dog8code.com:/restic-bucket --skip-ssl-verify
enter password for new repository: 
enter password again: 
created restic repository cd562a8cae at s3:https://s3-default.apps.cluster-sml4xaliosduf.sml4xaliosduf.mg.dog8code.com:/restic-bucket
```