### PR TITLE
Pull fusor-v0.9.4 commits into fusor-dev

### DIFF
--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -200,11 +200,11 @@ func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
 		}
 	}
 
-	err = res.RestoreTo(ctx, opts.Target)
+	err = res.RestoreTo(ctx, opts.Target, opts.SkipUnchanged)
 	if err == nil && opts.Verify {
 		Verbosef("verifying files in %s\n", opts.Target)
 		var count int
-		count, err = res.VerifyFiles(ctx, opts.Target)
+		count, err = res.VerifyFiles(ctx, opts.Target, opts.SkipUnchanged)
 		Verbosef("finished verifying %d files in %s\n", count, opts.Target)
 	}
 	if totalErrors > 0 {

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -385,7 +385,7 @@ func (arch *Archiver) Save(ctx context.Context, snPath, target string, previous 
 		}
 
 		// use previous node if the file hasn't changed
-		if previous != nil && !fileChanged(fi, previous, arch.IgnoreInode) {
+		if previous != nil && !FileChanged(fi, previous, arch.IgnoreInode) {
 			debug.Log("%v hasn't changed, returning old node", target)
 			arch.CompleteItem(snPath, previous, previous, ItemStats{}, time.Since(start))
 			arch.CompleteBlob(snPath, previous.Size)
@@ -436,9 +436,9 @@ func (arch *Archiver) Save(ctx context.Context, snPath, target string, previous 
 	return fn, false, nil
 }
 
-// fileChanged returns true if the file's content has changed since the node
+// FileChanged returns true if the file's content has changed since the node
 // was created.
-func fileChanged(fi os.FileInfo, node *restic.Node, ignoreInode bool) bool {
+func FileChanged(fi os.FileInfo, node *restic.Node, ignoreInode bool) bool {
 	if node == nil {
 		return true
 	}

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -627,14 +627,14 @@ func TestFileChanged(t *testing.T) {
 			fiBefore := lstat(t, filename)
 			node := nodeFromFI(t, filename, fiBefore)
 
-			if fileChanged(fiBefore, node, false) {
+			if FileChanged(fiBefore, node, false) {
 				t.Fatalf("unchanged file detected as changed")
 			}
 
 			test.Modify(t, filename)
 
 			fiAfter := lstat(t, filename)
-			if test.Check == fileChanged(fiAfter, node, test.IgnoreInode) {
+			if test.Check == FileChanged(fiAfter, node, test.IgnoreInode) {
 				if test.Check {
 					t.Fatalf("unmodified file detected as changed")
 				} else {
@@ -655,7 +655,7 @@ func TestFilChangedSpecialCases(t *testing.T) {
 
 	t.Run("nil-node", func(t *testing.T) {
 		fi := lstat(t, filename)
-		if !fileChanged(fi, nil, false) {
+		if !FileChanged(fi, nil, false) {
 			t.Fatal("nil node detected as unchanged")
 		}
 	})
@@ -664,7 +664,7 @@ func TestFilChangedSpecialCases(t *testing.T) {
 		fi := lstat(t, filename)
 		node := nodeFromFI(t, filename, fi)
 		node.Type = "symlink"
-		if !fileChanged(fi, node, false) {
+		if !FileChanged(fi, node, false) {
 			t.Fatal("node with changed type detected as unchanged")
 		}
 	})

--- a/internal/restorer/filesdeleter.go
+++ b/internal/restorer/filesdeleter.go
@@ -1,0 +1,65 @@
+package restorer
+
+import (
+	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/walker"
+
+	"context"
+	"os"
+	"path/filepath"
+)
+
+func DeleteFiles(ctx context.Context, target string, host string, paths []string, tags []restic.TagList, repo restic.Repository, id restic.ID) error {
+
+	var restorefiles, targetfiles, deletefiles []string
+
+	if err := repo.LoadIndex(ctx); err != nil {
+		return err
+	}
+
+	sn, err := restic.LoadSnapshot(context.TODO(), repo, id)
+	if err != nil {
+		return err
+	}
+
+	err = walker.Walk(ctx, repo, *sn.Tree, nil, func(_ restic.ID, nodepath string, node *restic.Node, err error) (bool, error) {
+		if err != nil {
+			return false, err
+		}
+		if node == nil {
+			return false, nil
+		}
+		restorefiles = append(restorefiles, filepath.Join(target, nodepath))
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	err = filepath.Walk(target, func(path string, info os.FileInfo, err error) error {
+		targetfiles = append(targetfiles, path)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, targetfile := range targetfiles {
+		var exists = false
+		for _, restorefile := range restorefiles {
+			if targetfile == restorefile || targetfile == target {
+				exists = true
+				break
+			}
+		}
+		if exists != true {
+			deletefiles = append(deletefiles, targetfile)
+		}
+	}
+
+	for _, deletefile := range deletefiles {
+		os.RemoveAll(deletefile)
+	}
+
+	return nil
+}

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/restic/restic/internal/crypto"
 	"github.com/restic/restic/internal/errors"
 
+	"github.com/restic/restic/internal/archiver"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/fs"
 	"github.com/restic/restic/internal/restic"
@@ -92,8 +93,8 @@ func (res *Restorer) traverseTree(ctx context.Context, target, location string, 
 
 		if skipUnchanged {
 			if targetFile, err := os.Stat(nodeTarget); !os.IsNotExist(err) {
-				if node.ModTime.Equal(targetFile.ModTime()) && node.Size == uint64(targetFile.Size()) {
-					debug.Log("Skipping target: %v\n", nodeTarget)
+				if !archiver.FileChanged(targetFile, node, true) {
+					debug.Log("Skipping target: %v\n", targetFile)
 					continue
 				}
 			}


### PR DESCRIPTION
In order to leave the release branch alone, we need to pull the commits on that branch onto fusor-dev, which is currently equivalent to the upstream 0.9.5 release. Upstream velero uses that now.