### PR TITLE
Group all Go dependency updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
 
   # Dependencies listed in .github/workflows/*.yml
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Dependabot was configured (`gomod` + `github-actions`, monthly) but had no groups, so Go module bumps arrive as one PR per dependency.

### Changes
- Add a catch-all `go-dependencies` group (pattern `*`) to the `gomod` entry so all Go module updates land in a single PR.
- `github-actions` entry and schedule intervals left untouched.

Matches the same grouping added in migtools/filebrowser#28.

> [!Note]
> Responses generated with Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated Go dependency updates into a single automated update group.
  * Existing GitHub Actions update configuration remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->